### PR TITLE
Allow drawing from a children nodes.

### DIFF
--- a/jquery.cytoscape.js-edgehandles.js
+++ b/jquery.cytoscape.js-edgehandles.js
@@ -814,7 +814,7 @@
                           
               hr = options().handleSize/2 * cy.zoom();
               hx = p.x;
-              hy = p.y - h/2 - hr/2;
+              hy = p.y - h/2 + hr/2;
 
               drawHandle(hx, hy, hr);
 


### PR DESCRIPTION
Handle was placed outside the node. When moving mouse over the handle, it triggered mouse over the parent node making it impossible/difficult to draw edge from a child node.
