### PR TITLE
Selective target hook

### DIFF
--- a/jquery.cytoscape.js-edgehandles.js
+++ b/jquery.cytoscape.js-edgehandles.js
@@ -622,6 +622,10 @@
             var node = this;
             var target = this;
 
+							if (options().canAccept && !options().canAccept( node)) {
+								return; // ignore nodes that don't accept edge to.
+							}
+							
 // console.log('mouseover hoverHandler')
 
             if( disabled() || drawMode || this.hasClass('edgehandles-preview') ){


### PR DESCRIPTION
To allow certain type of nodes to be the target nodes for drawing the edges to.
