### PR TITLE
fixed omitted variable declaration

### DIFF
--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -986,7 +986,7 @@
         },
 
         start: function( id ){
-          $container = $(this);
+          var $container = $(this);
 
           $container.cytoscape(function(e){
             var cy = this;


### PR DESCRIPTION
Hi,

There was an omitted variable declaration for `$container`, this was not triggering an error when using the lib but my IDE complained about it.

Chris
