### PR TITLE
Added a cancel-event

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,10 @@ var defaults = {
   complete: function( sourceNode, targetNodes, addedEntities ) {
     // fired when edgehandles is done and entities are added
   },
-  stop: function( sourceNode) {
+  stop: function( sourceNode ) {
     // fired when edgehandles interaction is stopped (either complete with added edges or incomplete)
   }, 
-  cancel: function(position){
+  cancel: function( position ){
     // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - position is where the edgehandle was released
   }
 };

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ var defaults = {
   stop: function( sourceNode ) {
     // fired when edgehandles interaction is stopped (either complete with added edges or incomplete)
   }, 
-  cancel: function( position ){
+  cancel: function( sourceNode, position ){
     // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - position is where the edgehandle was released
   }
 };

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ var defaults = {
   stop: function( sourceNode ) {
     // fired when edgehandles interaction is stopped (either complete with added edges or incomplete)
   }, 
-  cancel: function( sourceNode, position ){
-    // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - position is where the edgehandle was released
+  cancel: function( sourceNode, renderedPosition ){
+    // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - renderedPosition is where the edgehandle was released
   }
 };
 
@@ -130,7 +130,7 @@ On the source node:
  * `cyedgehandles.start` : when starting to drag on the handle
  * `cyedgehandles.stop` : when the handle is released
  * `cyedgehandles.complete` : when the handle has been released and edges are created
- * `cyedgehandles.cancel` : when the handle has been released but not on a valid target
+ * `cyedgehandles.cancel` : when the handle has been released but not on a valid target. The renderedPosition where the handle as releases is available as an extra paramater to the listener.
 
 On the target node:
 

--- a/README.md
+++ b/README.md
@@ -97,8 +97,11 @@ var defaults = {
   complete: function( sourceNode, targetNodes, addedEntities ) {
     // fired when edgehandles is done and entities are added
   },
-  stop: function( sourceNode ) {
+  stop: function( sourceNode) {
     // fired when edgehandles interaction is stopped (either complete with added edges or incomplete)
+  }, 
+  cancel: function(position){
+    // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - position is where the edgehandle was released
   }
 };
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ On the source node:
  * `cyedgehandles.start` : when starting to drag on the handle
  * `cyedgehandles.stop` : when the handle is released
  * `cyedgehandles.complete` : when the handle has been released and edges are created
+ * `cyedgehandles.cancel` : when the handle has been released but not on a valid target
 
 On the target node:
 

--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -449,6 +449,9 @@ SOFTWARE.
       },
       stop: function( sourceNode ) {
         // fired when edgehandles interaction is stopped (either complete with added edges or incomplete)
+      }, 
+      cancel: function(position) {
+        // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - position is where the edgehandle was released
       }
     };
 
@@ -533,6 +536,7 @@ SOFTWARE.
           var grabbingNode = false;
           var inForceStart = false;
           var hx, hy, hr;
+          var mx, my;
           var hoverTimeout;
           var drawsClear = true;
           var ghostNode;
@@ -825,6 +829,7 @@ SOFTWARE.
             }
 
             if( source.size() === 0 || targets.size() === 0 ) {
+              options().cancel({x: mx, y: my});
               return; // nothing to do :(
             }
 
@@ -1097,11 +1102,15 @@ SOFTWARE.
                 var x = pageX - $container.offset().left;
                 var y = pageY - $container.offset().top;
 
+                mx = x; 
+                my = y; 
+
                 if( options().handleLineType !== 'ghost' ) {
                   clearDraws();
                   drawHandle( hx, hy, hr );
                 }
                 drawLine( hx, hy, x, y );
+
 
                 return false;
               }
@@ -1214,6 +1223,9 @@ SOFTWARE.
                   var moveHandler = function( me ) {
                     var x = ( me.pageX !== undefined ? me.pageX : me.touches[ 0 ].pageX ) - $container.offset().left;
                     var y = ( me.pageY !== undefined ? me.pageY : me.touches[ 0 ].pageY ) - $container.offset().top;
+
+                    mx = x; 
+                    my = y; 
 
                     if( options().handleLineType !== 'ghost' ) {
                       clearDraws();

--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -829,7 +829,7 @@ SOFTWARE.
             }
 
             if( source.size() === 0 || targets.size() === 0 ) {
-              options().cancel(source, ({x: mx, y: my});
+              options().cancel(source, {x: mx, y: my});
               return; // nothing to do :(
             }
 

--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -450,7 +450,7 @@ SOFTWARE.
       stop: function( sourceNode ) {
         // fired when edgehandles interaction is stopped (either complete with added edges or incomplete)
       }, 
-      cancel: function(position) {
+      cancel: function( position ) {
         // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - position is where the edgehandle was released
       }
     };

--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -450,8 +450,8 @@ SOFTWARE.
       stop: function( sourceNode ) {
         // fired when edgehandles interaction is stopped (either complete with added edges or incomplete)
       }, 
-      cancel: function( sourceNode, position ) {
-        // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - position is where the edgehandle was released
+      cancel: function( sourceNode, renderedPosition ) {
+        // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - renderedPosition is where the edgehandle was released
       }
     };
 
@@ -830,6 +830,7 @@ SOFTWARE.
 
             if( source.size() === 0 || targets.size() === 0 ) {
               options().cancel(source, {x: mx, y: my});
+              source.trigger( 'cyedgehandles.cancel', {x: mx, y: my});
               return; // nothing to do :(
             }
 

--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -450,7 +450,7 @@ SOFTWARE.
       stop: function( sourceNode ) {
         // fired when edgehandles interaction is stopped (either complete with added edges or incomplete)
       }, 
-      cancel: function( position ) {
+      cancel: function( sourceNode, position ) {
         // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - position is where the edgehandle was released
       }
     };
@@ -829,7 +829,7 @@ SOFTWARE.
             }
 
             if( source.size() === 0 || targets.size() === 0 ) {
-              options().cancel({x: mx, y: my});
+              options().cancel(source, ({x: mx, y: my});
               return; // nothing to do :(
             }
 


### PR DESCRIPTION
I added a cancel-event, which only triggers when an edgehandle is released but not on top of a valid target, the reasoning being that since ```stop``` is always called - and is always called before ```complete``` there is no easy way to detect when an edgehandle is aborted without resorting to external state.

A use case for this, which is what I'm doing, is to create a new node when the user releases the edge handle without a pre-existing node.