### PR TITLE
Extended cancel-event with invalidTargets

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ These classes can be used for styling the graph as it interacts with the extensi
 * `edgehandles-preview` : Preview elements (used with `options.preview: true`)
 * `edgehandles-hover` : Added to nodes as they are hovered over as targets
 * `edgehandles-ghost-edge` : The ghost handle line edge
+* `edgehandles-presumptive-target` : A node that, during an edge drag, may become a target when released
 
 
 ## Events
@@ -131,7 +132,7 @@ On the source node:
  * `cyedgehandles.start` : when starting to drag on the handle
  * `cyedgehandles.stop` : when the handle is released
  * `cyedgehandles.complete` : when the handle has been released and edges are created
- * `cyedgehandles.cancel` : when the handle has been released but not on a valid target. The renderedPosition where the handle as releases is available as an extra paramater to the listener.
+ * `cyedgehandles.cancel` : when the handle has been released but not on a valid target. The handler receives two arguments - the renderedPosition at which the handle was released and a collection of presumptive targets. Presumptive targets are nodes that would have become targets but were, for some reason, deemed invalid. Possible reasons include `edgeType` or `loopAllowed` returning null.
 
 On the target node:
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ var defaults = {
   stop: function( sourceNode ) {
     // fired when edgehandles interaction is stopped (either complete with added edges or incomplete)
   }, 
-  cancel: function( sourceNode, renderedPosition ){
-    // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - renderedPosition is where the edgehandle was released
+  cancel: function( sourceNode, renderedPosition, invalidTarget ){
+    // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - renderedPosition is where the edgehandle was released, invalidTarget is
+        // a collection on which the handle was released, but which for other reasons (loopAllowed | edgeType) is an invalid target
   }
 };
 

--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -829,8 +829,9 @@ SOFTWARE.
             }
 
             if( source.size() === 0 || targets.size() === 0 ) {
-              options().cancel(source, {x: mx, y: my});
-              source.trigger( 'cyedgehandles.cancel', {x: mx, y: my});
+              let presumptiveTarget = cy.nodes( '.edgehandles-presumptiveTarget' );
+              options().cancel(source, {x: mx, y: my}, presumptiveTarget);
+              source.trigger( 'cyedgehandles.cancel', [{x: mx, y: my}, presumptiveTarget]);
               return; // nothing to do :(
             }
 
@@ -932,6 +933,9 @@ SOFTWARE.
               var isGhost = node.hasClass( 'edgehandles-ghost-node' );
               var noEdge = options().edgeType( source, node ) == null;
 
+              node.addClass('edgehandles-presumptiveTarget');
+
+
               if( isGhost || noEdge ) {
                 return;
               }
@@ -962,6 +966,8 @@ SOFTWARE.
               var source = sourceNode;
 
               node.removeClass( 'edgehandles-target' );
+              node.removeClass('edgehandles-presumptiveTarget');
+
               removePreview( source, target );
             }
           }

--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -666,7 +666,7 @@ SOFTWARE.
             cy.nodes()
               .removeClass( 'edgehandles-hover' )
               .removeClass( 'edgehandles-source' )
-              .removeClass( 'edgehandles-presumptiveTarget')
+              .removeClass( 'edgehandles-presumptive-target')
               .removeClass( 'edgehandles-target' );
 
             cy.$( '.edgehandles-ghost' ).remove();
@@ -831,7 +831,7 @@ SOFTWARE.
             }
 
             if( source.size() === 0 || targets.size() === 0 ) {
-              let presumptiveTarget = cy.nodes( '.edgehandles-presumptiveTarget' );
+              var presumptiveTarget = cy.nodes( '.edgehandles-presumptive-target' );
               options().cancel(source, {x: mx, y: my}, presumptiveTarget);
               source.trigger( 'cyedgehandles.cancel', [{x: mx, y: my}, presumptiveTarget]);
               return; // nothing to do :(
@@ -841,7 +841,6 @@ SOFTWARE.
             if( !src && !tgt ) {
               if( !preview && options().preview ) {
                 added = cy.elements( '.edgehandles-preview' ).removeClass( 'edgehandles-preview' );
-console.log("laer")
                 options().complete( source, targets, added );
                 source.trigger( 'cyedgehandles.complete' );
                 return;
@@ -918,7 +917,6 @@ console.log("laer")
             }
 
             if( !preview ) {
-              console.log("run!")
               options().complete( source, targets, added );
               source.trigger( 'cyedgehandles.complete' );
             }
@@ -936,7 +934,7 @@ console.log("laer")
               var isGhost = node.hasClass( 'edgehandles-ghost-node' );
               var noEdge = options().edgeType( source, node ) == null;
 
-              node.addClass('edgehandles-presumptiveTarget');
+              node.addClass('edgehandles-presumptive-target');
 
 
               if( isGhost || noEdge ) {
@@ -969,7 +967,7 @@ console.log("laer")
               var source = sourceNode;
 
               node.removeClass( 'edgehandles-target' );
-              node.removeClass('edgehandles-presumptiveTarget');
+              node.removeClass( 'edgehandles-presumptive-target' );
 
               removePreview( source, target );
             }

--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -665,6 +665,7 @@ SOFTWARE.
             cy.nodes()
               .removeClass( 'edgehandles-hover' )
               .removeClass( 'edgehandles-source' )
+              .removeClass( 'edgehandles-presumptiveTarget')
               .removeClass( 'edgehandles-target' );
 
             cy.$( '.edgehandles-ghost' ).remove();
@@ -839,7 +840,7 @@ SOFTWARE.
             if( !src && !tgt ) {
               if( !preview && options().preview ) {
                 added = cy.elements( '.edgehandles-preview' ).removeClass( 'edgehandles-preview' );
-
+console.log("laer")
                 options().complete( source, targets, added );
                 source.trigger( 'cyedgehandles.complete' );
                 return;
@@ -916,6 +917,7 @@ SOFTWARE.
             }
 
             if( !preview ) {
+              console.log("run!")
               options().complete( source, targets, added );
               source.trigger( 'cyedgehandles.complete' );
             }

--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -450,8 +450,9 @@ SOFTWARE.
       stop: function( sourceNode ) {
         // fired when edgehandles interaction is stopped (either complete with added edges or incomplete)
       }, 
-      cancel: function( sourceNode, renderedPosition ) {
-        // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - renderedPosition is where the edgehandle was released
+      cancel: function( sourceNode, renderedPosition, invalidTarget ) {
+        // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - renderedPosition is where the edgehandle was released, invalidTarget is
+        // a collection on which the handle was released, but which for other reasons (loopAllowed | edgeType) is an invalid target
       }
     };
 


### PR DESCRIPTION
I found myself needing to know if the edgehandle was released on some node(s) but which, in turn, was deemed invalid targets (most probably by either loopAllowed or edgeType). 