### PR TITLE
Removed misplaced "return;"

### DIFF
--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -1157,7 +1157,6 @@ SOFTWARE.
               }
 
             } ).on( 'tap', 'node', tapToStartHandler = function() {
-              return;
               var node = this;
 
               if( !sourceNode ) { // must not be active


### PR DESCRIPTION
There was a "return;" right after the "tap" event handler(Line 1160). This was stopping the code below to be executed.