### PR TITLE
Removed a U+00A0 no-break space and replaced it with a U+0020 space. …

### DIFF
--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -211,7 +211,7 @@ SOFTWARE.
       stop: function( sourceNode ) {
         // fired when edgehandles interaction is stopped (either complete with added edges or incomplete)
       },
-      cancel: function( sourceNode, renderedPosition, invalidTarget ) {
+      cancel: function( sourceNode, renderedPosition, invalidTarget ) {
         // fired when edgehandles are cancelled ( incomplete - nothing has been added ) - renderedPosition is where the edgehandle was released, invalidTarget is
         // a collection on which the handle was released, but which for other reasons (loopAllowed | edgeType) is an invalid target
       }


### PR DESCRIPTION
…It was causing a 'cy.edgehandles is not a function' error.