### PR TITLE
Prevent drawing an edge whenever the extension is disabled

### DIFF
--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -1126,6 +1126,10 @@ SOFTWARE.
             } ).on( 'cxttapstart tapstart', 'node', cxtstartHandler = function( e ) {
               var node = this;
 
+              if( disabled() ) {
+                return; // prevent drawing an edge whenever the extension is disabled
+              }
+
               if( node.filter( options().handleNodes ).length === 0 ) {
                 return; // skip if node not allowed
               }


### PR DESCRIPTION
This PR cancels the`cxttapstart tapstart` event when the extension is disabled (just like how `mouseover tap` is canceled)