### PR TITLE
Set mx,my on ctxdrag to ensure cancel works properly in drawMode

### DIFF
--- a/cytoscape-edgehandles.js
+++ b/cytoscape-edgehandles.js
@@ -1178,8 +1178,11 @@ SOFTWARE.
                 var rpos = e.renderedPosition || e.cyRenderedPosition;
 
                 drawLine( rpos.x, rpos.y );
-
+                mx = rpos.x;
+                my = rpos.y;
               }
+
+
 
 
             } ).on( 'cxtdragover tapdragover', 'node', cxtdragoverHandler = function( e ) {


### PR DESCRIPTION
I discovered a bug in the cancel-management I submitted earlier where it wouldn't work properly then cxt/drawMode was used - this pull request fixes the bug!