### PR TITLE
Make handle node not selectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ cytoscape-edgehandles
 
 ## Description
 
-
-This extension creates handles on nodes that can be dragged to create edges between nodes ([demo](https://cytoscape.github.io/cytoscape.js-edgehandles/))
+This extension lets one create edges by either dragging the edge handle of a node or performing a context drag directly between nodes 
+([demo](https://cytoscape.github.io/cytoscape.js-edgehandles/))
 
 
 ## Dependencies
@@ -69,6 +69,7 @@ let cy = cytoscape({
 // the default values of each option are outlined below:
 let defaults = {
   preview: true, // whether to show added edges preview before releasing selection
+  draw: false, // whether to enable drawing edges with right-click mousedrag or two-finger tabdrag
   hoverDelay: 150, // time spent hovering over a target node before it is considered selected
   handleNodes: 'node', // selector/filter function for whether edges can be made from a given node
   handlePosition: function( node ){

--- a/demo.html
+++ b/demo.html
@@ -141,7 +141,7 @@
 					}
 				});
 
-				var eh = cy.edgehandles();
+				var eh = cy.edgehandles({draw: true});
 
 				document.querySelector('#draw-on').addEventListener('click', function() {
 					eh.enableDrawMode();

--- a/src/edgehandles/cy-listeners.js
+++ b/src/edgehandles/cy-listeners.js
@@ -61,6 +61,47 @@ function addCytoscapeListeners(){
     this.stop();
   } );
 
+  // start on cxttapstart (right-click mousedown or twofinger tabstart)
+  this.addListener( cy, 'cxttapstart', 'node', e => {
+    if (!this.options.draw) return;
+
+    let node = e.target;
+
+    if( node.same( this.handleNode ) ){
+      this.start( this.sourceNode );
+    } else {
+      this.start( node );
+    }
+  } );
+
+  // update line on drag
+  this.addListener( cy, 'tapdrag', e => {
+      if (!this.options.draw) return;
+
+      this.update( e.position );
+  } );
+
+  // hover over preview
+  this.addListener( cy, 'cxtdragover', 'node', e => {
+      if (!this.options.draw) return;
+
+      this.preview( e.target );
+  } );
+
+  // hover out unpreview
+  this.addListener( cy, 'cxtdragout', 'node', e => {
+      if (!this.options.draw) return;
+
+      this.unpreview( e.target );
+  } );
+
+  // stop gesture on cxttapend
+  this.addListener( cy, 'cxttapend', () => {
+      if (!this.options.draw) return;
+
+      this.stop();
+  } );
+
   // hide handle if source node is removed
   this.addListener( cy, 'remove', e => {
     if( e.target.same( this.sourceNode ) ){

--- a/src/edgehandles/defaults.js
+++ b/src/edgehandles/defaults.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars */
 let defaults = {
   preview: true, // whether to show added edges preview before releasing selection
+  draw: false, // whether to enable drawing edges from node with right-click mousedrag or two-finger tabdrag
   hoverDelay: 150, // time spent hovering over a target node before it is considered selected
   handleNodes: 'node', // selector/filter function for whether edges can be made from a given node
   handlePosition: function( node ){

--- a/src/edgehandles/drawing.js
+++ b/src/edgehandles/drawing.js
@@ -195,7 +195,8 @@ function setHandleFor( node ){
       this.handleNode = cy.add({
         classes: 'eh-handle',
         position: pos,
-        grabbable: false
+        grabbable: false,
+        selectable: false
       });
 
       this.handleNode.style('z-index', 9007199254740991);


### PR DESCRIPTION
This fix will prevent the handle node from being selected when performing a box selection