### PR TITLE
Restart edges on edge tap

### DIFF
--- a/src/edgehandles/cy-listeners.js
+++ b/src/edgehandles/cy-listeners.js
@@ -41,6 +41,20 @@ function addCytoscapeListeners(){
     }
   } );
 
+  this.addListener( cy, 'tapstart', 'edge', e => {
+    const edge = e.target;
+
+    const source = edge.source();
+
+    edge.remove();
+
+    this.start( source );
+
+    // almost, just need the targets to accept it
+
+    // this.emit('restart', this.hp(), source);
+  } );
+
   // update line on drag
   this.addListener( cy, 'tapdrag', e => {
     this.update( e.position );

--- a/src/edgehandles/defaults.js
+++ b/src/edgehandles/defaults.js
@@ -44,6 +44,9 @@ let defaults = {
   hide: function( sourceNode ){
     // fired when the handle is hidden
   },
+  restart: function restart(sourceNode) {
+    // fired when edgehandles interaction restarts (drag on edge)
+  },
   start: function( sourceNode ){
     // fired when edgehandles interaction starts (drag on handle)
   },


### PR DESCRIPTION
I cannot  get the preview to start when dragging the arrow to a new target.
The edge will be removed if its just tapped without a drag. I only want it removed if it is dragged.

I noticed that `tapdrag` fires when mousing over the canvas, without a tap or a drag. So I am not yet familiar enough with the API to complete this.

https://github.com/cytoscape/cytoscape.js-edgehandles/issues/146